### PR TITLE
Fix condition to match RAdam author's impl.

### DIFF
--- a/keras_radam/optimizer_v2.py
+++ b/keras_radam/optimizer_v2.py
@@ -195,7 +195,7 @@ class RAdam(OptimizerV2):
                             (sma_t - 2.0) / (sma_inf - 2.0) *
                             sma_inf / sma_t)
 
-        var_t = tf.where(sma_t > 5.0, r_t * m_corr_t / v_corr_t, m_corr_t)
+        var_t = tf.where(sma_t >= 5.0, r_t * m_corr_t / v_corr_t, m_corr_t)
 
         if self._initial_weight_decay > 0.0:
             var_t += self._get_hyper('weight_decay', var_dtype) * var

--- a/keras_radam/optimizer_v2.py
+++ b/keras_radam/optimizer_v2.py
@@ -132,7 +132,7 @@ class RAdam(OptimizerV2):
                             (sma_t - 2.0) / (sma_inf - 2.0) *
                             sma_inf / sma_t)
 
-        var_t = tf.where(sma_t > 5.0, r_t * m_corr_t / v_corr_t, m_corr_t)
+        var_t = tf.where(sma_t >= 5.0, r_t * m_corr_t / v_corr_t, m_corr_t)
 
         if self._initial_weight_decay > 0.0:
             var_t += self._get_hyper('weight_decay', var_dtype) * var

--- a/keras_radam/optimizers.py
+++ b/keras_radam/optimizers.py
@@ -100,7 +100,7 @@ class RAdam(keras.optimizers.Optimizer):
                          (sma_t - 2.0) / (sma_inf - 2.0) *
                          sma_inf / sma_t)
 
-            p_t = K.switch(sma_t > 5, r_t * m_corr_t / v_corr_t, m_corr_t)
+            p_t = K.switch(sma_t >= 5, r_t * m_corr_t / v_corr_t, m_corr_t)
 
             if self.initial_weight_decay > 0:
                 p_t += self.weight_decay * p

--- a/keras_radam/training.py
+++ b/keras_radam/training.py
@@ -167,7 +167,7 @@ class RAdamOptimizer(optimizer.Optimizer):
                             (sma_t - 2.0) / (sma_inf - 2.0) *
                             sma_inf / sma_t)
 
-        var_t = tf.where(sma_t > 5.0, r_t * m_corr_t / v_corr_t, m_corr_t)
+        var_t = tf.where(sma_t >= 5.0, r_t * m_corr_t / v_corr_t, m_corr_t)
 
         if self._initial_weight_decay > 0.0:
             var_t += math_ops.cast(self._weight_decay_t, var.dtype.base_dtype) * var
@@ -226,7 +226,7 @@ class RAdamOptimizer(optimizer.Optimizer):
                             (sma_t - 2.0) / (sma_inf - 2.0) *
                             sma_inf / sma_t)
 
-        var_t = tf.where(sma_t > 5.0, r_t * m_corr_t / v_corr_t, m_corr_t)
+        var_t = tf.where(sma_t >= 5.0, r_t * m_corr_t / v_corr_t, m_corr_t)
 
         if self._initial_weight_decay > 0.0:
             var_t += math_ops.cast(self._weight_decay_t, var.dtype.base_dtype) * var


### PR DESCRIPTION
An authors implementation of `RAdam` uses `>= 5` when weights are updated. 

https://github.com/LiyuanLucasLiu/RAdam/blob/2266a22fb0df53893dca5d003044fd9efca40e75/radam.py#L60-L64

It probably make sense to use same condition, taking into account `t` is from `1 .. T` range.

BTW, [parer](https://arxiv.org/pdf/1908.03265v1.pdf) uses `> 4` and `t` from range `1 .. T`, not sure why is that, but I've considered implementation more accurate than paper in this case.

