### PR TITLE
Change lr decay logic

### DIFF
--- a/keras_radam/optimizers.py
+++ b/keras_radam/optimizers.py
@@ -66,8 +66,8 @@ class RAdam(keras.optimizers.Optimizer):
             decay_rate = (self.min_lr - lr) / decay_steps
             lr = K.switch(
                 t <= warmup_steps,
-                lr*(t / warmup_steps),
-                lr + decay_rate*K.minimum(t-warmup_steps,decay_steps)
+                lr * (t / warmup_steps),
+                lr + decay_rate * K.minimum(t - warmup_steps, decay_steps)
             )
 
         ms = [K.zeros(K.int_shape(p), dtype=K.dtype(p), name='m_' + str(i)) for (i, p) in enumerate(params)]

--- a/keras_radam/optimizers.py
+++ b/keras_radam/optimizers.py
@@ -59,13 +59,15 @@ class RAdam(keras.optimizers.Optimizer):
             lr = lr * (1. / (1. + self.decay * K.cast(self.iterations, K.dtype(self.decay))))
 
         t = K.cast(self.iterations, K.floatx()) + 1
-
+        
         if self.initial_total_steps > 0:
             warmup_steps = self.total_steps * self.warmup_proportion
+            decay_steps  = self.total_steps - warmup_steps
+            decay_rate   = (self.min_lr - lr)/decay_steps
             lr = K.switch(
                 t <= warmup_steps,
                 lr * (t / warmup_steps),
-                self.min_lr + (lr - self.min_lr) * (1.0 - K.minimum(t, self.total_steps) / self.total_steps),
+                lr + decay_rate*K.minimum(t-warmup_steps,decay_steps)
             )
 
         ms = [K.zeros(K.int_shape(p), dtype=K.dtype(p), name='m_' + str(i)) for (i, p) in enumerate(params)]

--- a/keras_radam/optimizers.py
+++ b/keras_radam/optimizers.py
@@ -62,13 +62,12 @@ class RAdam(keras.optimizers.Optimizer):
         
         if self.initial_total_steps > 0:
             warmup_steps = self.total_steps * self.warmup_proportion
-            decay_steps  = self.total_steps - warmup_steps
+            decay_steps  = K.maximum(self.total_steps - warmup_steps,1)
             decay_rate   = (self.min_lr - lr)/decay_steps
-            lr = K.switch(
-                t <= warmup_steps,
-                lr * (t / warmup_steps),
-                lr + decay_rate*K.minimum(t-warmup_steps,decay_steps)
-            )
+            lr = K.switch(t <= warmup_steps, 
+                          lr*(t / warmup_steps), 
+                          lr + decay_rate*K.minimum(t-warmup_steps,decay_steps)
+                         )
 
         ms = [K.zeros(K.int_shape(p), dtype=K.dtype(p), name='m_' + str(i)) for (i, p) in enumerate(params)]
         vs = [K.zeros(K.int_shape(p), dtype=K.dtype(p), name='v_' + str(i)) for (i, p) in enumerate(params)]

--- a/keras_radam/optimizers.py
+++ b/keras_radam/optimizers.py
@@ -59,15 +59,16 @@ class RAdam(keras.optimizers.Optimizer):
             lr = lr * (1. / (1. + self.decay * K.cast(self.iterations, K.dtype(self.decay))))
 
         t = K.cast(self.iterations, K.floatx()) + 1
-        
+
         if self.initial_total_steps > 0:
             warmup_steps = self.total_steps * self.warmup_proportion
-            decay_steps  = K.maximum(self.total_steps - warmup_steps,1)
-            decay_rate   = (self.min_lr - lr)/decay_steps
-            lr = K.switch(t <= warmup_steps, 
-                          lr*(t / warmup_steps), 
-                          lr + decay_rate*K.minimum(t-warmup_steps,decay_steps)
-                         )
+            decay_steps = K.maximum(self.total_steps - warmup_steps, 1)
+            decay_rate = (self.min_lr - lr) / decay_steps
+            lr = K.switch(
+                t <= warmup_steps,
+                lr*(t / warmup_steps),
+                lr + decay_rate*K.minimum(t-warmup_steps,decay_steps)
+            )
 
         ms = [K.zeros(K.int_shape(p), dtype=K.dtype(p), name='m_' + str(i)) for (i, p) in enumerate(params)]
         vs = [K.zeros(K.int_shape(p), dtype=K.dtype(p), name='v_' + str(i)) for (i, p) in enumerate(params)]


### PR DESCRIPTION
Once `t > warmup_steps`, the movement toward `min_lr` is abrupt. _Ex:_ `self.total_steps = 200`, `warmup_steps = 60`, `self.lr = 1e-3`, `self.min_lr = 1e-4`:

- `t = 59 `  --> `lr = 9.9e-4`
- `t = 60` --> `lr = 1.0e-3` 
- `t = 61` --> `lr = 7.3e-4`

Doubt this is intended behavior. Plot ([code](https://puu.sh/E8IBI/88b1c7634c.txt)) comparison below. Furthermore, since `min_lr` can be set greater than `lr` (i.e. initial lr), perhaps a more neutral name is suitable - e.g. `final_lr` - and since the original `self.lr` is modified several times, renaming it to `self.init_lr` would be more intuitive - but neither are included in this PR.

<hr>

![image](https://user-images.githubusercontent.com/16495490/63619016-96bc7480-c5bb-11e9-9e91-e32a2a8ebde4.png)